### PR TITLE
REFACTOR: Change link to theme-full tag to only show themes.

### DIFF
--- a/javascripts/discourse/templates/components/meta-banner.hbs
+++ b/javascripts/discourse/templates/components/meta-banner.hbs
@@ -14,7 +14,7 @@
             </a>
           </div>
           <div>
-            <a href="https://meta.discourse.org/c/theme/61/none">
+            <a href="https://meta.discourse.org/tags/c/theme/61/none/theme-full">
               <h3>{{d-icon "palette"}}
                 {{theme-i18n "meta_banner.themes"}}</h3>
             </a>


### PR DESCRIPTION
I think changing the link to show users only `themes` would be good for this link, instead of the latest on the category as sometimes lots of components show up depending on the conversation.