### PR TITLE
UX: support links in description

### DIFF
--- a/javascripts/discourse/components/branded-banner.gjs
+++ b/javascripts/discourse/components/branded-banner.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
+import { htmlSafe } from "@ember/template";
 import { defaultHomepage } from "discourse/lib/utilities";
 import icon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
@@ -23,7 +24,7 @@ export default class BrandedBanner extends Component {
           <div class="custom-banner__content-wrapper">
             <div class="custom-banner__intro">
               <h1>{{i18n (themePrefix "meta_banner.welcome")}}</h1>
-              <p>{{i18n (themePrefix "meta_banner.subtitle")}}</p>
+              <p>{{htmlSafe (i18n (themePrefix "meta_banner.subtitle"))}}</p>
             </div>
             <div class="custom-banner__list">
               {{#each settings.links as |link|}}


### PR DESCRIPTION
This allows for links in the banner text on the left here:

![image](https://github.com/user-attachments/assets/2e10901f-a07b-44cc-8cf7-b9aef1608c14)
